### PR TITLE
Update validateMaf.R

### DIFF
--- a/R/validateMaf.R
+++ b/R/validateMaf.R
@@ -6,7 +6,7 @@ validateMaf = function(maf, rdup = TRUE, isTCGA = isTCGA, chatty = TRUE){
 
   #Change column names to standard names; i.e, camel case
   for(i in 1:length(required.fields)){
-    colId = suppressWarnings(grep(pattern = required.fields[i], x = colnames(maf), ignore.case = TRUE))
+    colId = suppressWarnings(grep(pattern = paste("^",required.fields[i],"$",sep=""), x = colnames(maf), ignore.case = TRUE))
     if(length(colId) > 0){
       colnames(maf)[colId] = required.fields[i]
     }


### PR DESCRIPTION
This corrects a bug caused by columns that contain a substring that exactly matches a required column. These were erroneously being converted to the same name, which can cause the wrong column to be used from the original MAF.